### PR TITLE
[Feature] : QueryDSL & Swagger & Cors 설정 추가

### DIFF
--- a/oversweet-api/build.gradle
+++ b/oversweet-api/build.gradle
@@ -4,7 +4,10 @@ dependencies {
     implementation project(':oversweet-domain')
 
     // 모듈에 맞는 의존성 추가
+    // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 

--- a/oversweet-api/src/main/java/com/depromeet/oversweet/TestController.java
+++ b/oversweet-api/src/main/java/com/depromeet/oversweet/TestController.java
@@ -2,15 +2,20 @@ package com.depromeet.oversweet;
 
 
 import com.depromeet.oversweet.domain.franchise.service.FranchisePureService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+import java.util.List;
+
+@Tag(name = "Test", description = "테스트 API")
+@RestController("/api/v1")
 @RequiredArgsConstructor
 public class TestController {
 
     private final FranchisePureService franchisePureService;
+
 
     @GetMapping("/test")
     public String test() {
@@ -27,6 +32,11 @@ public class TestController {
     @GetMapping("test-db-connection")
     public String testDbConnection() {
         return franchisePureService.getFranchiseName(1L);
+    }
+
+    @GetMapping("test-querydsl")
+    public List<String> testQuerydsl() {
+        return franchisePureService.getFranchiseNames(List.of(1L, 2L));
     }
 
 }

--- a/oversweet-api/src/main/resources/application-local.yml
+++ b/oversweet-api/src/main/resources/application-local.yml
@@ -1,9 +1,12 @@
 spring:
+  # DB
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3307/oversweet?allowPublicKeyRetrieval=true&useUnicode=true&useSSL=false&serverTimezone=Asia/Seoul
     username: root
     password: root
+
+  # JPA
   jpa:
     hibernate:
       ddl-auto: create
@@ -18,8 +21,5 @@ logging:
   level:
     org:
       hibernate:
-        type:
-          descriptor:
-            sql: trace # SQL 파라미터가 어떤 값이 들어가는지 확인 가능
         SQL: debug # SQL 쿼리 확인 가능 (JPQL X)
 

--- a/oversweet-common/build.gradle
+++ b/oversweet-common/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
-
+    // swagger 설정, oversweet-api 모듈에서 사용해야 하기에 implementation 대신 api 사용
+    api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 

--- a/oversweet-common/src/main/java/com/depromeet/oversweet/config/WebMvcConfig.java
+++ b/oversweet-common/src/main/java/com/depromeet/oversweet/config/WebMvcConfig.java
@@ -1,0 +1,33 @@
+package com.depromeet.oversweet.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**")
+                .allowedOrigins("http://localhost:3000") // 프론트의 도메인 주소를 추후에 설정할 수 있음
+                // Set the list of headers that a pre-flight request can list as allowed for use during an actual request.
+                .allowedHeaders("*")
+                .allowedMethods(
+                        HttpMethod.GET.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.DELETE.name(),
+                        HttpMethod.PATCH.name(),
+                        HttpMethod.HEAD.name(),
+                        HttpMethod.OPTIONS.name()
+                )
+                // allow to use cookies (쿠키 사용을 허용할지 여부) : cookie에 저장된 refresh token을 사용하기 위해 필요
+                .allowCredentials(true)
+                // allow to read response Authorization header
+                .exposedHeaders("Authorization", "Set-Cookie");
+
+    }
+}

--- a/oversweet-common/src/main/java/com/depromeet/oversweet/swagger/OpenApiConfig.java
+++ b/oversweet-common/src/main/java/com/depromeet/oversweet/swagger/OpenApiConfig.java
@@ -1,0 +1,24 @@
+package com.depromeet.oversweet.swagger;
+
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI springOpenAPI() {
+        Info info = new Info()
+                .title("OverSweet Core Server API")
+                .description("OverSweet Core API 명세서입니다.")
+                .version("v0.0.1");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+
+}

--- a/oversweet-domain/build.gradle
+++ b/oversweet-domain/build.gradle
@@ -3,8 +3,20 @@ dependencies {
     implementation project(':oversweet-common')
 
     // 모듈에 맞는 의존성 추가
+    // data jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // mysql
     implementation 'mysql:mysql-connector-java:8.0.33'
+
+    // h2
     runtimeOnly 'com.h2database:h2'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseEntityFilter.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseEntityFilter.java
@@ -1,0 +1,14 @@
+package com.depromeet.oversweet.domain.franchise.repository;
+
+import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
+
+import java.util.List;
+
+/**
+ * 프랜차이즈를 필터링을 통해서 조회하는 커스텀 인터페이스.
+ */
+public interface FranchiseEntityFilter {
+
+    List<FranchiseEntity> findAllByFranchiseIds(List<Long> franchiseIds);
+
+}

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseEntityFilterImpl.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseEntityFilterImpl.java
@@ -1,0 +1,43 @@
+package com.depromeet.oversweet.domain.franchise.repository;
+
+import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.util.List;
+
+import static com.depromeet.oversweet.domain.franchise.entity.QFranchiseEntity.franchiseEntity;
+
+/**
+ * 프랜차이즈를 필터링을 통해서 조회하는 커스텀 인터페이스의 구현체
+ */
+public class FranchiseEntityFilterImpl implements FranchiseEntityFilter {
+
+    private final JPAQueryFactory queryFactory;
+
+    public FranchiseEntityFilterImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    /**
+     * 프랜차이즈 아이디 목록을 통해 프랜차이즈 목록을 조회
+     * @param franchiseIds 프랜차이즈 아이디 목록
+     * @return 프랜차이즈 목록
+     */
+    @Override
+    public List<FranchiseEntity> findAllByFranchiseIds(List<Long> franchiseIds) {
+        return queryFactory
+                .selectFrom(franchiseEntity)
+                .where(idsIn(franchiseIds))
+                .fetch();
+    }
+
+    /**
+     * 프랜차이즈 아이디 목록을 통해 프랜차이즈 목록을 조회하는 쿼리 조건
+     * @param franchiseIds 프랜차이즈 아이디 목록
+     */
+    private BooleanExpression idsIn(List<Long> franchiseIds) {
+        return franchiseEntity.id.in(franchiseIds);
+    }
+}

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseEntityRepository.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseEntityRepository.java
@@ -3,6 +3,6 @@ package com.depromeet.oversweet.domain.franchise.repository;
 import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FranchiseEntityRepository extends JpaRepository<FranchiseEntity, Long> {
+public interface FranchiseEntityRepository extends JpaRepository<FranchiseEntity, Long>, FranchiseEntityFilter {
 
 }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/service/FranchisePureService.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/service/FranchisePureService.java
@@ -1,19 +1,45 @@
 package com.depromeet.oversweet.domain.franchise.service;
 
+import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
 import com.depromeet.oversweet.domain.franchise.repository.FranchiseEntityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 프랜차이즈에 대한 순수 Service.
+ * 의존성은 FranchiseEntityRepository 만 갖는다.
+ * 주로 Optional 에 대한 처리를 하고 온전한 Entity 를 반환한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class FranchisePureService {
 
     private final FranchiseEntityRepository franchiseEntityRepository;
 
+    /**
+     * 프랜차이즈 이름을 반환한다.
+     * @param franchiseId 프랜차이즈 아이디
+     * @return 프랜차이즈 이름
+     */
     public String getFranchiseName(Long franchiseId) {
         return franchiseEntityRepository.findById(franchiseId)
                 .orElseThrow(() -> new RuntimeException("프랜차이즈가 존재하지 않습니다."))
                 .getName();
+    }
+
+    /**
+     * 프랜차이즈 이름 목록을 반환한다.
+     * @param franchiseIds 프랜차이즈 아이디 목록
+     * @return 프랜차이즈 이름 목록
+     */
+    public List<String> getFranchiseNames(List<Long> franchiseIds) {
+        return franchiseEntityRepository.findAllByFranchiseIds(franchiseIds)
+                .stream()
+                .map(FranchiseEntity::getName)
+                .collect(Collectors.toList());
     }
 
 


### PR DESCRIPTION
## ❗️관련 이슈번호
Close #10 

## ⚙️ 어떤 기능을 개발했나요?
- QueryDSL 의존성 및 설정 추가
- Swagger 의존성 및 설정 추가
- Cors 설정 추가

## 🙋🏻 어떤 부분에 집중하여 리뷰해야 할까요?
- `allowCredentials(true)` 로 설정하면 allowedOrigins 설정은 ("*") 할 수 없다 하여, 프론트 작업 포트인 localhost:3000으로만 열어줬습니다.
추후, 도메인 주소를 넣으면 될 것 같아요
- Authorization 와 Cookie을 프론트에서 사용하기 위해 exposedHeaders 설정을 추가 했습니다. 
- Swagger 설정을 Common 모듈에 추가했고 , Swagger 에서 제공하는 Tag 문법을 사용하기 위해 implementation 대신 api 를 사용했습니다.
 ```
// swagger 설정, oversweet-api 모듈에서 사용해야 하기에 implementation 대신 api 사용
    api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
```


