### PR TITLE
✨ [Feat] 유저가 즐겨찾기한 프랜차이즈 목록 조회 기능 구현

### DIFF
--- a/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/controller/BookmarkController.java
+++ b/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/controller/BookmarkController.java
@@ -1,0 +1,42 @@
+package com.depromeet.oversweet.bookmark.controller;
+
+import com.depromeet.oversweet.bookmark.dto.FranchiseBookMarkedResponseDto;
+import com.depromeet.oversweet.bookmark.service.FranchiseBookMarkSearchService;
+import com.depromeet.oversweet.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Tag(name = "즐겨찾기", description = "즐겨찾기 관련 API")
+@RestController
+@RequestMapping("/api/v1/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final FranchiseBookMarkSearchService franchiseBookMarkSearchService;
+
+
+    /**
+     * 유저가 즐겨 찾기한 프랜차이즈 목록 조회
+     * 추후 로그인 기능 구현 후, 로그인한 유저의 ID를 받아와야 함 (ex. @AuthenticationPrincipal User user)
+     */
+    @Operation(summary = "즐겨 찾기한 프랜차이즈 목록 조회", description = "유저가 즐겨 찾기한 프랜차이즈 목록을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200", description = "즐겨 찾기한 프랜차이즈 목록을 조회 성공")
+    })
+    @GetMapping("/franchises")
+    public ResponseEntity<DataResponse<FranchiseBookMarkedResponseDto>> searchFranchiseBookMarked() {
+        FranchiseBookMarkedResponseDto responseDto = franchiseBookMarkSearchService.searchFranchiseBookMarked(100L);
+        return new ResponseEntity<>(DataResponse.of(OK, "즐겨 찾기한 프랜차이즈 목록을 조회 성공", responseDto), OK);
+    }
+
+}

--- a/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/controller/BookmarkController.java
+++ b/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/controller/BookmarkController.java
@@ -36,7 +36,7 @@ public class BookmarkController {
     @GetMapping("/franchises")
     public ResponseEntity<DataResponse<FranchiseBookMarkedResponseDto>> searchFranchiseBookMarked() {
         FranchiseBookMarkedResponseDto responseDto = franchiseBookMarkSearchService.searchFranchiseBookMarked(100L);
-        return new ResponseEntity<>(DataResponse.of(OK, "즐겨 찾기한 프랜차이즈 목록을 조회 성공", responseDto), OK);
+        return ResponseEntity.ok(DataResponse.of(OK, "즐겨 찾기한 프랜차이즈 목록 조회 성공", responseDto));
     }
 
 }

--- a/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/dto/FranchiseBookMarkedInfo.java
+++ b/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/dto/FranchiseBookMarkedInfo.java
@@ -1,0 +1,31 @@
+package com.depromeet.oversweet.bookmark.dto;
+
+import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+/**
+ * 유저가 즐겨 찾기한 프랜차이즈 정보 DTO
+ */
+@Getter
+public class FranchiseBookMarkedInfo {
+
+    @Schema(description = "프랜차이즈 ID", example = "1")
+    private final long id;
+
+    @Schema(description = "프랜차이즈 이미지 URL")
+    private final String imageUrl;
+
+    @Schema(description = "프랜차이즈 이름", example = "스타벅스")
+    private final String name;
+
+    public FranchiseBookMarkedInfo(long id, String imageUrl, String name) {
+        this.id = id;
+        this.imageUrl = imageUrl;
+        this.name = name;
+    }
+
+    public FranchiseBookMarkedInfo(FranchiseBookmarkEntity bookMark) {
+        this(bookMark.getId(), bookMark.getFranchise().getImageUrl(), bookMark.getFranchise().getName());
+    }
+}

--- a/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/dto/FranchiseBookMarkedResponseDto.java
+++ b/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/dto/FranchiseBookMarkedResponseDto.java
@@ -1,0 +1,24 @@
+package com.depromeet.oversweet.bookmark.dto;
+
+import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 유저가 즐겨찾기 한 프랜차이즈 목록 응답 DTO
+ */
+@Getter
+public class FranchiseBookMarkedResponseDto {
+
+
+    @Schema(description = "즐겨찾기한 프랜차이즈 목록", example = "[]")
+    private final List<FranchiseBookMarkedInfo> bookMarkedFranchises;
+
+    public FranchiseBookMarkedResponseDto(List<FranchiseBookmarkEntity> bookMarks) {
+        this.bookMarkedFranchises = bookMarks.stream()
+                .map(FranchiseBookMarkedInfo::new)
+                .toList();
+    }
+}

--- a/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/service/FranchiseBookMarkSearchService.java
+++ b/oversweet-api/src/main/java/com/depromeet/oversweet/bookmark/service/FranchiseBookMarkSearchService.java
@@ -1,0 +1,30 @@
+package com.depromeet.oversweet.bookmark.service;
+
+import com.depromeet.oversweet.bookmark.dto.FranchiseBookMarkedResponseDto;
+import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+import com.depromeet.oversweet.domain.bookmark.repository.FindFranchiseBookMarkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 프랜차이즈 즐겨찾기 검색 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class FranchiseBookMarkSearchService {
+
+    private final FindFranchiseBookMarkRepository findFranchiseBookMarkRepository;
+
+    /**
+     * 유저가 즐겨 찾기한 프랜차이즈 목록 조회
+     *
+     * @param memberId 유저 ID
+     * @return 즐겨찾기한 프랜차이즈 목록
+     */
+    public FranchiseBookMarkedResponseDto searchFranchiseBookMarked(final Long memberId) {
+        final List<FranchiseBookmarkEntity> bookMarks = findFranchiseBookMarkRepository.findByMemberId(memberId);
+        return new FranchiseBookMarkedResponseDto(bookMarks);
+    }
+}

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/OversweetDomainApplication.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/OversweetDomainApplication.java
@@ -1,0 +1,12 @@
+package com.depromeet.oversweet;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OversweetDomainApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OversweetDomainApplication.class, args);
+    }
+}

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/entity/FranchiseBookmarkEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/entity/FranchiseBookmarkEntity.java
@@ -14,10 +14,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Table(name = "franchise_bookmark")
 @Entity
@@ -39,8 +39,9 @@ public class FranchiseBookmarkEntity extends BaseTimeEntity {
     private FranchiseEntity franchise;
 
 
-    public FranchiseBookmarkEntity(MemberEntity member, FranchiseEntity franchise, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        super(createdAt, updatedAt);
+    @Builder
+    public FranchiseBookmarkEntity(Long id, MemberEntity member, FranchiseEntity franchise) {
+        this.id = id;
         this.member = member;
         this.franchise = franchise;
     }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/entity/FranchiseBookmarkEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/entity/FranchiseBookmarkEntity.java
@@ -17,6 +17,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Table(name = "franchise_bookmark")
 @Entity
 @Getter
@@ -35,4 +37,11 @@ public class FranchiseBookmarkEntity extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "franchise_id", foreignKey = @ForeignKey(name = "fk_franchiseBookmark_to_franchise"), nullable = false)
     private FranchiseEntity franchise;
+
+
+    public FranchiseBookmarkEntity(MemberEntity member, FranchiseEntity franchise, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.member = member;
+        this.franchise = franchise;
+    }
 }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/repository/FindFranchiseBookMarkRepository.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/repository/FindFranchiseBookMarkRepository.java
@@ -1,0 +1,12 @@
+package com.depromeet.oversweet.domain.bookmark.repository;
+
+import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+
+import java.util.List;
+
+/**
+ * 즐겨 찾기한 프랜차이즈 조회 Interface
+ */
+public interface FindFranchiseBookMarkRepository {
+    List<FranchiseBookmarkEntity> findByMemberId(final Long memberId);
+}

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/repository/FindFranchiseBookMarkRepositoryImpl.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/repository/FindFranchiseBookMarkRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.depromeet.oversweet.domain.bookmark.repository;
+
+import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 프랜차이즈 즐겨찾기 조회 레포지토리
+ * 주로 optional 처리를 담당하며, 상위 service 계층에는 optional을 반환하지 않는다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class FindFranchiseBookMarkRepositoryImpl implements FindFranchiseBookMarkRepository {
+
+    private final FranchiseBookMarkJpaRepository franchiseBookMarkJpaRepository;
+
+    /**
+     * 유저가 즐겨 찾기한 프랜차이즈 Entity 목록 조회
+     *
+     * @param memberId 유저 ID
+     * @return 즐겨찾기한 프랜차이즈 Entity 목록
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<FranchiseBookmarkEntity> findByMemberId(final Long memberId) {
+        return franchiseBookMarkJpaRepository.findByMemberId(memberId);
+    }
+}

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/repository/FranchiseBookMarkJpaRepository.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/bookmark/repository/FranchiseBookMarkJpaRepository.java
@@ -1,0 +1,10 @@
+package com.depromeet.oversweet.domain.bookmark.repository;
+
+import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FranchiseBookMarkJpaRepository extends JpaRepository<FranchiseBookmarkEntity, Long> {
+    List<FranchiseBookmarkEntity> findByMemberId(final Long memberId);
+}

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/common/entity/BaseTimeEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/common/entity/BaseTimeEntity.java
@@ -23,11 +23,4 @@ public class BaseTimeEntity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public BaseTimeEntity() {
-    }
-
-    public BaseTimeEntity(LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
 }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/common/entity/BaseTimeEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/common/entity/BaseTimeEntity.java
@@ -22,4 +22,12 @@ public class BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public BaseTimeEntity() {
+    }
+
+    public BaseTimeEntity(LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/entity/FranchiseEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/entity/FranchiseEntity.java
@@ -12,7 +12,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Table(name = "franchise")
 @Entity
@@ -32,8 +31,7 @@ public class FranchiseEntity extends BaseTimeEntity {
     private String imageUrl;
 
     @Builder
-    public FranchiseEntity(Long id, String name, String imageUrl, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        super(createdAt, updatedAt);
+    public FranchiseEntity(Long id, String name, String imageUrl) {
         this.id = id;
         this.name = name;
         this.imageUrl = imageUrl;

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/entity/FranchiseEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/entity/FranchiseEntity.java
@@ -8,8 +8,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Table(name = "franchise")
 @Entity
@@ -27,4 +30,12 @@ public class FranchiseEntity extends BaseTimeEntity {
 
     @Column(name = "image_url")
     private String imageUrl;
+
+    @Builder
+    public FranchiseEntity(Long id, String name, String imageUrl, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseJpaRepository.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/repository/FranchiseJpaRepository.java
@@ -3,6 +3,6 @@ package com.depromeet.oversweet.domain.franchise.repository;
 import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FranchiseEntityRepository extends JpaRepository<FranchiseEntity, Long>, FranchiseEntityFilter {
+public interface FranchiseJpaRepository extends JpaRepository<FranchiseEntity, Long>, FranchiseEntityFilter {
 
 }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/service/FranchisePureService.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/franchise/service/FranchisePureService.java
@@ -1,7 +1,7 @@
 package com.depromeet.oversweet.domain.franchise.service;
 
 import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
-import com.depromeet.oversweet.domain.franchise.repository.FranchiseEntityRepository;
+import com.depromeet.oversweet.domain.franchise.repository.FranchiseJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FranchisePureService {
 
-    private final FranchiseEntityRepository franchiseEntityRepository;
+    private final FranchiseJpaRepository franchiseJpaRepository;
 
     /**
      * 프랜차이즈 이름을 반환한다.
@@ -25,7 +25,7 @@ public class FranchisePureService {
      * @return 프랜차이즈 이름
      */
     public String getFranchiseName(Long franchiseId) {
-        return franchiseEntityRepository.findById(franchiseId)
+        return franchiseJpaRepository.findById(franchiseId)
                 .orElseThrow(() -> new RuntimeException("프랜차이즈가 존재하지 않습니다."))
                 .getName();
     }
@@ -36,7 +36,7 @@ public class FranchisePureService {
      * @return 프랜차이즈 이름 목록
      */
     public List<String> getFranchiseNames(List<Long> franchiseIds) {
-        return franchiseEntityRepository.findAllByFranchiseIds(franchiseIds)
+        return franchiseJpaRepository.findAllByFranchiseIds(franchiseIds)
                 .stream()
                 .map(FranchiseEntity::getName)
                 .collect(Collectors.toList());

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/member/entity/MemberEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/member/entity/MemberEntity.java
@@ -12,8 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Table(name = "member")
 @Entity
@@ -57,4 +60,20 @@ public class MemberEntity extends BaseTimeEntity {
 
     @Column(name = "daily_sugar")
     private Integer dailySugar;
+
+    @Builder
+    public MemberEntity(Long id, String nickname, String email, SocialProvider socialProvider, String socialId, String imageUrl, Gender gender, Integer weight, Integer height, Integer age, Integer dailySugar, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+        this.socialProvider = socialProvider;
+        this.socialId = socialId;
+        this.imageUrl = imageUrl;
+        this.gender = gender;
+        this.weight = weight;
+        this.height = height;
+        this.age = age;
+        this.dailySugar = dailySugar;
+    }
 }

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/member/entity/MemberEntity.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/member/entity/MemberEntity.java
@@ -16,7 +16,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Table(name = "member")
 @Entity
@@ -62,8 +61,7 @@ public class MemberEntity extends BaseTimeEntity {
     private Integer dailySugar;
 
     @Builder
-    public MemberEntity(Long id, String nickname, String email, SocialProvider socialProvider, String socialId, String imageUrl, Gender gender, Integer weight, Integer height, Integer age, Integer dailySugar, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        super(createdAt, updatedAt);
+    public MemberEntity(Long id, String nickname, String email, SocialProvider socialProvider, String socialId, String imageUrl, Gender gender, Integer weight, Integer height, Integer age, Integer dailySugar) {
         this.id = id;
         this.nickname = nickname;
         this.email = email;

--- a/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/member/repository/MemberJpaRepository.java
+++ b/oversweet-domain/src/main/java/com/depromeet/oversweet/domain/member/repository/MemberJpaRepository.java
@@ -1,0 +1,7 @@
+package com.depromeet.oversweet.domain.member.repository;
+
+import com.depromeet.oversweet.domain.member.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
+}

--- a/oversweet-domain/src/test/java/com/depromeet/oversweet/domain/bookmark/repository/FranchiseBookMarkJpaRepositoryTest.java
+++ b/oversweet-domain/src/test/java/com/depromeet/oversweet/domain/bookmark/repository/FranchiseBookMarkJpaRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.depromeet.oversweet.domain.bookmark.repository;
 
 import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+import com.depromeet.oversweet.domain.config.JpaEntityConfig;
 import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
 import com.depromeet.oversweet.domain.franchise.repository.FranchiseJpaRepository;
 import com.depromeet.oversweet.domain.member.entity.MemberEntity;
@@ -10,15 +11,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.context.annotation.Import;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ *  @DataJpaTest 는 JpaTest에 필요한 최소한의 빈을 불러오는데, 거기에는 @Configuration 빈이 포함되어있지 않다.
+ *  따라서 @Configuration을 사용하여 따로 JpaConfig 파일을 만들었을 경우,
+ *  @Import(JpaConfig.class) 를 통해 JpaConfig 파일을 불러와야 한다.
+ */
 @DataJpaTest
-@ContextConfiguration(classes = {FranchiseBookMarkJpaRepository.class, MemberJpaRepository.class, FranchiseJpaRepository.class})
+@Import(JpaEntityConfig.class)
 class FranchiseBookMarkJpaRepositoryTest {
 
     private final FranchiseBookMarkJpaRepository franchiseBookMarkJpaRepository;
@@ -44,8 +49,6 @@ class FranchiseBookMarkJpaRepositoryTest {
                 .id(1L)
                 .socialId("socialId")
                 .socialProvider(SocialProvider.KAKAO)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
                 .build();
 
         memberJpaRepository.save(memberEntity);
@@ -53,13 +56,16 @@ class FranchiseBookMarkJpaRepositoryTest {
         FranchiseEntity franchiseEntity = FranchiseEntity.builder()
                 .id(1L)
                 .name("스타벅스")
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
                 .build();
 
         franchiseJpaRepository.save(franchiseEntity);
 
-        franchiseBookMarkJpaRepository.save(new FranchiseBookmarkEntity(memberEntity, franchiseEntity, LocalDateTime.now(), LocalDateTime.now()));
+        FranchiseBookmarkEntity franchiseBookmarkEntity = FranchiseBookmarkEntity.builder()
+                .member(memberEntity)
+                .franchise(franchiseEntity)
+                .build();
+
+        franchiseBookMarkJpaRepository.save(franchiseBookmarkEntity);
     }
 
     @Test

--- a/oversweet-domain/src/test/java/com/depromeet/oversweet/domain/bookmark/repository/FranchiseBookMarkJpaRepositoryTest.java
+++ b/oversweet-domain/src/test/java/com/depromeet/oversweet/domain/bookmark/repository/FranchiseBookMarkJpaRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.depromeet.oversweet.domain.bookmark.repository;
+
+import com.depromeet.oversweet.domain.bookmark.entity.FranchiseBookmarkEntity;
+import com.depromeet.oversweet.domain.franchise.entity.FranchiseEntity;
+import com.depromeet.oversweet.domain.franchise.repository.FranchiseJpaRepository;
+import com.depromeet.oversweet.domain.member.entity.MemberEntity;
+import com.depromeet.oversweet.domain.member.enums.SocialProvider;
+import com.depromeet.oversweet.domain.member.repository.MemberJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = {FranchiseBookMarkJpaRepository.class, MemberJpaRepository.class, FranchiseJpaRepository.class})
+class FranchiseBookMarkJpaRepositoryTest {
+
+    private final FranchiseBookMarkJpaRepository franchiseBookMarkJpaRepository;
+
+    private final MemberJpaRepository memberJpaRepository;
+
+    private final FranchiseJpaRepository franchiseJpaRepository;
+
+    @Autowired
+    public FranchiseBookMarkJpaRepositoryTest(FranchiseBookMarkJpaRepository franchiseBookMarkJpaRepository,
+                                              MemberJpaRepository memberJpaRepository,
+                                              FranchiseJpaRepository franchiseJpaRepository) {
+        this.franchiseBookMarkJpaRepository = franchiseBookMarkJpaRepository;
+        this.memberJpaRepository = memberJpaRepository;
+        this.franchiseJpaRepository = franchiseJpaRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        // DataJpaTest 를 사용하기 위해 entity의 필수값을 모두 넣어줘야 한다.
+        // createdAt, updatedAt 은 Spring Boot Test가 아닌 DataJpaTest에 의해 값을 채워넣지 못 해 직접 넣어줘야 한다.
+        MemberEntity memberEntity = MemberEntity.builder()
+                .id(1L)
+                .socialId("socialId")
+                .socialProvider(SocialProvider.KAKAO)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        memberJpaRepository.save(memberEntity);
+
+        FranchiseEntity franchiseEntity = FranchiseEntity.builder()
+                .id(1L)
+                .name("스타벅스")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        franchiseJpaRepository.save(franchiseEntity);
+
+        franchiseBookMarkJpaRepository.save(new FranchiseBookmarkEntity(memberEntity, franchiseEntity, LocalDateTime.now(), LocalDateTime.now()));
+    }
+
+    @Test
+    void 유저의_고유_ID를_통해서_즐겨찾기한_프랜차이즈_목록_조회() {
+        // given
+        long memberId = 1L;
+
+        // when
+        List<FranchiseBookmarkEntity> bookMarks = franchiseBookMarkJpaRepository.findByMemberId(memberId);
+
+        // then
+        assertThat(bookMarks).hasSize(1);
+    }
+}


### PR DESCRIPTION
## ❗️관련 이슈번호
Close #18 

## ⚙️ 어떤 기능을 개발했나요?
- 유저가 즐겨찾기한 프랜차이즈 목록 조회 기능 구현.
- Data JPA Naming Method (findByMemberId) 동작 검증을 위한 Test Code 추가.

## 🙋🏻 어떤 부분에 집중하여 리뷰해야 할까요?
- DataJpaTest를 수행하기 위해 Domain 모듈의 최상단 패키지에 SpingBootAplication 어노테이션이 붙은 Application.class를 만들었습니다.
- 응답 Dto 같은 경우는 재사용성이 보여 inner class로 만들지 않았습니다.
- API 요청한 유저가 누구인지 판단하기 위해 Security Context Holder에 담긴 API에 접근한 유저의 정보(id)를 알아야 하는데 아직 코드 개발이 이루어지지 않아, 임의로 100L으로 설정하고, 추후에 다시 리펙토링 예정입니다


## 🔥어떻게 해결했나요?
- Naming Method 규칙이 헷갈려 직접 `DataJpaTest` 어노테이션을 활용하여 Test Code를 작성하고자 했습니다.
  - DataJpaTest를 수행하기 위해선, **SpringBootApplication 어노테이션이 존재해야 하는데 존재하지 않았습니다. 따라서 직접 상위 패키지에 만들었습니다.**
  - SpringBootApplication을 사용하지 않고, ContextConfiguration 을 사용하여 Test에 필요한 Bean 들을 직접 띄우는 방법도 있었습니다, 하지만 이렇게 하면 DataJpaTest는 기본적으로 Spring Data JPA에서 정의된 Repository 인터페이스의 구현체를 자동으로 등록할 수 없고, 직접 Code를 통해서 JpaRepository를 Bean으로 띄워야 합니다. 이러한 방향은 **DataJpaTest가 제공하는 자동 구성을 무시**하는 것이므로 맞지 않다 판단했습니다.
  - 또한, DataJpaTest를 수행하면 **JpaTest에 필요한 최소한의 빈을 불러오는데, 거기에는 Configuration 빈이 포함되어있지 않습니다.**  따라서 JpaAuditing 을 활용하고자 따로 Configuration 어노테이션을 이용하여 Bean으로 만들고자 했던 JpaEntityConfig class가 빈으로 등록되지 않은 문제점이 있습니다. 앞서 설명대로 DataJpaTest 수행 시 Configuration 빈은 포함되지 않기에 **Import** 을 통해서 해결했습니다.


