### PR TITLE
🚑 [Hotfix] 필터링 조건에 따라 음료 목록 조회를 할 때 가장 작은 사이즈가 없을 경우 해당 데이터를 제외하도록 수정했어요.

### DIFF
--- a/oversweet-api/src/main/java/com/depromeet/oversweet/search/service/DrinkSearchService.java
+++ b/oversweet-api/src/main/java/com/depromeet/oversweet/search/service/DrinkSearchService.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
@@ -66,11 +67,13 @@ public class DrinkSearchService {
                                 //프랜차이즈별 && 음료명별 안에서 가장 작은 사이즈의 음료와 그 음료가 가지는 사이즈 list 를 찾아서 넣어준다.
                                 List<DrinkEntity> drinkEntities = innerEntry.getValue();
 
-                                DrinkEntity minimumDrinkEntity = drinkEntities.stream().filter(DrinkEntity::getIsMinimum).findFirst().get();
-                                List<Integer> sizes = drinkEntities.stream().map(DrinkEntity::getSize).sorted().toList();
+                                Optional<DrinkEntity> minimumDrinkEntityOptional = drinkEntities.stream().filter(DrinkEntity::getIsMinimum).findFirst();
+                                if (minimumDrinkEntityOptional.isPresent()) {
+                                    List<Integer> sizes = drinkEntities.stream().map(DrinkEntity::getSize).sorted().toList();
 
-                                DrinkAllInfoResponse drinkAllInfoResponse = DrinkAllInfoResponse.of(minimumDrinkEntity, sizes);
-                                drinkAllInfoResponses.add(drinkAllInfoResponse);
+                                    DrinkAllInfoResponse drinkAllInfoResponse = DrinkAllInfoResponse.of(minimumDrinkEntityOptional.get(), sizes);
+                                    drinkAllInfoResponses.add(drinkAllInfoResponse);
+                                }
                             });
                 });
 


### PR DESCRIPTION
## ❗️관련 이슈번호
Close #74 

## ⚙️ 어떤 기능을 개발했나요?
- 프랜차이즈 ID, 음료 카테고리, 정렬 조건에 따라 음료 목록 조회 시 가장 작은 사이즈가 없는 음료 데이터의 경우는 제외하도록 로직 수정

## 🙋🏻 어떤 부분에 집중하여 리뷰해야 할까요?
- Optional 로 데이터 가져와서 isPresent 로 존재 여부 확인 후 데이터를 넣었어요.
